### PR TITLE
Implement GameState and Api refactor

### DIFF
--- a/src/action_ameliorer.cc
+++ b/src/action_ameliorer.cc
@@ -19,16 +19,16 @@
 
 #include "actions.hh"
 
-int ActionAmeliorer::check(const GameState* st) const
+int ActionAmeliorer::check(const GameState& st) const
 {
-    case_type ct = st->get_cell_type(position_);
+    case_type ct = st.get_cell_type(position_);
     if (ct == case_type::INTERDIT)
         return POSITION_INVALIDE;
     if (ct == case_type::SUPER_TUYAU)
         return AMELIORATION_IMPOSSIBLE;
     if (ct != case_type::TUYAU)
         return AUCUN_TUYAU;
-    if (st->get_action_points() < COUT_AMELIORATION)
+    if (st.get_action_points() < COUT_AMELIORATION)
         return PA_INSUFFISANTS;
     return OK;
 }

--- a/src/action_ameliorer.hh
+++ b/src/action_ameliorer.hh
@@ -36,7 +36,7 @@ public:
     }
     ActionAmeliorer() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_construire.cc
+++ b/src/action_construire.cc
@@ -19,14 +19,14 @@
 
 #include "actions.hh"
 
-int ActionConstruire::check(const GameState* st) const
+int ActionConstruire::check(const GameState& st) const
 {
-    case_type ct = st->get_cell_type(position_);
+    case_type ct = st.get_cell_type(position_);
     if (ct == case_type::INTERDIT)
         return POSITION_INVALIDE;
     if (ct != case_type::VIDE)
         return CONSTRUCTION_IMPOSSIBLE;
-    if (st->get_action_points() < COUT_CONSTRUCTION)
+    if (st.get_action_points() < COUT_CONSTRUCTION)
         return PA_INSUFFISANTS;
     return OK;
 }

--- a/src/action_construire.hh
+++ b/src/action_construire.hh
@@ -36,7 +36,7 @@ public:
     }
     ActionConstruire() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_deblayer.cc
+++ b/src/action_deblayer.cc
@@ -19,14 +19,14 @@
 
 #include "actions.hh"
 
-int ActionDeblayer::check(const GameState* st) const
+int ActionDeblayer::check(const GameState& st) const
 {
-    case_type ct = st->get_cell_type(position_);
+    case_type ct = st.get_cell_type(position_);
     if (ct == case_type::INTERDIT)
         return POSITION_INVALIDE;
     if (ct != case_type::DEBRIS)
         return PAS_DE_DEBRIS;
-    if (st->get_action_points() < COUT_DEBLAYAGE)
+    if (st.get_action_points() < COUT_DEBLAYAGE)
         return PA_INSUFFISANTS;
     return OK;
 }

--- a/src/action_deblayer.hh
+++ b/src/action_deblayer.hh
@@ -36,7 +36,7 @@ public:
     }
     ActionDeblayer() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_deplacer_aspiration.cc
+++ b/src/action_deplacer_aspiration.cc
@@ -19,25 +19,25 @@
 
 #include "actions.hh"
 
-int ActionDeplacerAspiration::check(const GameState* st) const
+int ActionDeplacerAspiration::check(const GameState& st) const
 {
-    case_type source = st->get_cell_type(source_);
-    case_type destination = st->get_cell_type(destination_);
+    case_type source = st.get_cell_type(source_);
+    case_type destination = st.get_cell_type(destination_);
     if (source == case_type::INTERDIT || destination == case_type::INTERDIT)
         return POSITION_INVALIDE;
     if (source_ == destination_)
         return DEPLACEMENT_INVALIDE;
     if (source != case_type::BASE || destination != case_type::BASE)
         return PAS_DANS_BASE;
-    if (st->get_cell_owner(source_) != static_cast<unsigned>(player_id_) ||
-        st->get_cell_owner(destination_) != static_cast<unsigned>(player_id_))
+    if (st.get_cell_owner(source_) != static_cast<unsigned>(player_id_) ||
+        st.get_cell_owner(destination_) != static_cast<unsigned>(player_id_))
         return PAS_DANS_BASE;
-    if (st->get_vacuum(source_) <= 0)
+    if (st.get_vacuum(source_) <= 0)
         return PUISSANCE_INSUFFISANTE;
-    if (st->get_vacuum(destination_) >= LIMITE_ASPIRATION)
+    if (st.get_vacuum(destination_) >= LIMITE_ASPIRATION)
         return LIMITE_ASPIRATION_ATTEINTE;
-    if (st->get_vacuum_moved() &&
-        st->get_action_points() < COUT_MODIFICATION_ASPIRATION)
+    if (st.get_vacuum_moved() &&
+        st.get_action_points() < COUT_MODIFICATION_ASPIRATION)
         return PA_INSUFFISANTS;
     return OK;
 }

--- a/src/action_deplacer_aspiration.hh
+++ b/src/action_deplacer_aspiration.hh
@@ -38,7 +38,7 @@ public:
     }
     ActionDeplacerAspiration() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_detruire.cc
+++ b/src/action_detruire.cc
@@ -19,19 +19,19 @@
 
 #include "actions.hh"
 
-int ActionDetruire::check(const GameState* st) const
+int ActionDetruire::check(const GameState& st) const
 {
-    case_type ct = st->get_cell_type(position_);
+    case_type ct = st.get_cell_type(position_);
     if (ct == case_type::INTERDIT)
         return POSITION_INVALIDE;
     if (ct != case_type::TUYAU && ct != case_type::SUPER_TUYAU)
         return DESTRUCTION_IMPOSSIBLE;
-    unsigned points = st->get_action_points();
+    unsigned points = st.get_action_points();
     if (points < COUT_DESTRUCTION)
         return PA_INSUFFISANTS;
     if (ct == case_type::SUPER_TUYAU && points < COUT_DESTRUCTION_SUPER_TUYAU)
         return PA_INSUFFISANTS;
-    if (st->get_player_info().at(player_id_).get_collected_plasma() <
+    if (st.get_player_info().at(player_id_).get_collected_plasma() <
         CHARGE_DESTRUCTION)
         return CHARGE_INSUFFISANTE;
     return OK;

--- a/src/action_detruire.hh
+++ b/src/action_detruire.hh
@@ -36,7 +36,7 @@ public:
     }
     ActionDetruire() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/api.cc
+++ b/src/api.cc
@@ -319,14 +319,3 @@ int Api::tour_actuel()
 {
     return game_state_->get_turn();
 }
-
-/// Annule la dernière action. Renvoie ``false`` quand il n'y a pas d'action à
-/// annuler ce tour-ci.
-bool Api::annuler()
-{
-    if (!game_state_.can_cancel())
-        return false;
-    actions_.cancel();
-    game_state_.cancel();
-    return true;
-}

--- a/src/api.cc
+++ b/src/api.cc
@@ -25,82 +25,15 @@
 // global used in interface.cc
 Api* api;
 
-Api::Api(const GameStateWrapper& game_state, rules::Player_sptr player)
-    : game_state_(game_state)
-    , player_(std::move(player))
+Api::Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
+    : rules::Api<GameState, erreur>(std::move(game_state), player)
+    , construire(this)
+    , ameliorer(this)
+    , detruire(this)
+    , deplacer_aspiration(this)
+    , deblayer(this)
 {
     api = this;
-}
-
-/// Construit un tuyau sur une case donnée.
-erreur Api::construire(position position)
-{
-    rules::IAction_sptr action(new ActionConstruire(position, player_->id));
-
-    erreur err;
-    if ((err = static_cast<erreur>(action->check(game_state_))) != OK)
-        return err;
-
-    actions_.add(action);
-    game_state_set(action->apply(game_state_));
-    return OK;
-}
-
-/// Améliore un tuyau en Super Tuyau™.
-erreur Api::ameliorer(position position)
-{
-    rules::IAction_sptr action(new ActionAmeliorer(position, player_->id));
-
-    erreur err;
-    if ((err = static_cast<erreur>(action->check(game_state_))) != OK)
-        return err;
-
-    actions_.add(action);
-    game_state_set(action->apply(game_state_));
-    return OK;
-}
-
-/// Détruit un tuyau sur une case donnée.
-erreur Api::detruire(position position)
-{
-    rules::IAction_sptr action(new ActionDetruire(position, player_->id));
-
-    erreur err;
-    if ((err = static_cast<erreur>(action->check(game_state_))) != OK)
-        return err;
-
-    actions_.add(action);
-    game_state_set(action->apply(game_state_));
-    return OK;
-}
-
-/// Déplace un point d'aspiration d'un point de la base vers l'autre.
-erreur Api::deplacer_aspiration(position source, position destination)
-{
-    rules::IAction_sptr action(
-        new ActionDeplacerAspiration(source, destination, player_->id));
-
-    erreur err;
-    if ((err = static_cast<erreur>(action->check(game_state_))) != OK)
-        return err;
-
-    actions_.add(action);
-    game_state_set(action->apply(game_state_));
-    return OK;
-}
-
-/// Déblaye une case de débris.
-erreur Api::deblayer(position position)
-{
-    rules::IAction_sptr action(new ActionDeblayer(position, player_->id));
-
-    erreur err;
-    if ((err = static_cast<erreur>(action->check(game_state_))) != OK)
-        return err;
-
-    actions_.add(action);
-    game_state_set(action->apply(game_state_));
-    return OK;
 }
 
 /// Renvoie le type d'une case donnée.
@@ -391,9 +324,9 @@ int Api::tour_actuel()
 /// annuler ce tour-ci.
 bool Api::annuler()
 {
-    if (!game_state_->can_cancel())
+    if (!game_state_.can_cancel())
         return false;
     actions_.cancel();
-    game_state_ = rules::cancel(game_state_.operator GameState*());
+    game_state_.cancel();
     return true;
 }

--- a/src/api.hh
+++ b/src/api.hh
@@ -165,10 +165,6 @@ public:
 
     /// Renvoie le numéro du tour actuel.
     int tour_actuel();
-
-    /// Annule la dernière action. Renvoie ``false`` quand il n'y a pas d'action
-    /// à annuler ce tour-ci.
-    bool annuler();
 };
 
 #endif /* !API_HH_ */

--- a/src/dumper.cc
+++ b/src/dumper.cc
@@ -206,7 +206,7 @@ static void dump_stream(std::ostream& ss, const GameState& st)
 
 void Rules::dump_state(std::ostream& ss)
 {
-    dump_stream(ss, *api_->game_state());
+    dump_stream(ss, api_->game_state());
 }
 
 // from api.cc
@@ -218,7 +218,7 @@ extern "C" const char* dump_state_json()
     // return values by free-ing them.
     static std::string s;
     std::ostringstream ss;
-    dump_stream(ss, *api->game_state());
+    dump_stream(ss, api->game_state());
     s = ss.str();
     return s.c_str();
 }

--- a/src/game_state.cc
+++ b/src/game_state.cc
@@ -89,7 +89,7 @@ GameState::GameState(std::istream& board_stream, rules::Players_sptr players)
     }
 }
 
-rules::GameState* GameState::copy() const
+GameState* GameState::copy() const
 {
     return new GameState(*this);
 }

--- a/src/game_state.hh
+++ b/src/game_state.hh
@@ -107,7 +107,7 @@ public:
     // The input stream consists of simply five integers for every pulsar:
     // x y periode puissance nombre_pulsations
     GameState(std::istream&, rules::Players_sptr players);
-    rules::GameState* copy() const final override;
+    GameState* copy() const final override;
 
     const auto& get_player_info() const { return player_info_; }
     auto& get_player_info() { return player_info_; }

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -459,7 +459,7 @@ extern "C" int api_tour_actuel()
 /// annuler ce tour-ci.
 extern "C" bool api_annuler()
 {
-    return api->annuler();
+    return api->cancel();
 }
 
 /// Affiche le contenu d'une valeur de type erreur

--- a/src/rules.cc
+++ b/src/rules.cc
@@ -17,8 +17,8 @@
 ** along with Prologin2016.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "rules.hh"
 #include "actions.hh"
+#include "rules.hh"
 #include <fstream>
 
 Rules::Rules(const rules::Options opt)
@@ -40,8 +40,8 @@ Rules::Rules(const rules::Options opt)
     if (!ifs.is_open())
         FATAL("Cannot open file: %s", opt.map_file.c_str());
 
-    GameStateWrapper game_state(new GameState(ifs, opt.players));
-    api_ = std::make_unique<Api>(game_state, opt.player);
+    auto game_state = std::make_unique<GameState>(ifs, opt.players);
+    api_ = std::make_unique<Api>(std::move(game_state), opt.player);
     register_actions();
 }
 
@@ -76,12 +76,12 @@ void Rules::apply_action(const rules::IAction_sptr& action)
     // client/server desynchronizations and make sure the gamestate is always
     // consistent across the clients and the server.
 
-    int err = action->check(api_->game_state());
+    int err = api_->game_state_check(action);
     if (err)
         FATAL("Synchronization error: received action %d from player %d, but "
               "check() on current gamestate returned %d.",
               action->id(), action->player_id(), err);
-    api_->game_state_set(action->apply(api_->game_state()));
+    api_->game_state_apply(action);
 }
 
 void Rules::at_player_start(rules::ClientMessenger_sptr)
@@ -137,24 +137,24 @@ void Rules::spectator_turn()
 
 void Rules::start_of_player_turn(uint32_t player_id)
 {
-    api_->game_state()->reset_action_points();
-    api_->game_state()->increment_turn();
-    api_->game_state()->set_vacuum_moved(false);
-    api_->game_state()->reset_history(player_id);
+    api_->game_state().reset_action_points();
+    api_->game_state().increment_turn();
+    api_->game_state().set_vacuum_moved(false);
+    api_->game_state().reset_history(player_id);
 }
 
 void Rules::end_of_player_turn(uint32_t /* player_id */)
 {
-    api_->game_state()->move_plasma();
-    api_->game_state()->emit_plasma();
+    api_->game_state().move_plasma();
+    api_->game_state().emit_plasma();
 
-    // Clear the list of game states at the end of each turn (half-round)
-    // We need the linked list of game states only for undo and history,
-    // therefore old states are not needed anymore after the turn ends.
-    api_->game_state()->clear_old_version();
+    // Clear the previous game states at the end of each turn (half-round)
+    // We need the previous game states only for undo and history, therefore
+    // old states are not needed anymore after the turn ends.
+    api_->clear_old_game_states();
 }
 
 bool Rules::is_finished()
 {
-    return api_->game_state()->get_turn() >= NB_TOURS;
+    return api_->game_state().get_turn() >= NB_TOURS;
 }

--- a/src/rules.hh
+++ b/src/rules.hh
@@ -61,7 +61,7 @@ public:
     void dump_state(std::ostream& out) override;
 
     /// Get game state for tests purpose
-    GameState* get_game_state() const { return api_->game_state(); }
+    GameState& get_game_state() const { return api_->game_state(); }
 
 protected:
     f_champion_partie_init champion_partie_init_;

--- a/src/tests/test-action_ameliorer.cc
+++ b/src/tests/test-action_ameliorer.cc
@@ -9,12 +9,12 @@ TEST_F(ActionTest, Ameliorer_InvalidCell)
     ActionAmeliorer* act;
 
     act = new ActionAmeliorer(TEST_PULSAR_POSITION, PLAYER_1);
-    EXPECT_EQ(AUCUN_TUYAU, act->check(st));
+    EXPECT_EQ(AUCUN_TUYAU, act->check(*st));
     EXPECT_EQ(PULSAR, st->get_cell_type(TEST_PULSAR_POSITION));
     delete act;
 
     act = new ActionAmeliorer({0, 0}, PLAYER_1);
-    EXPECT_EQ(POSITION_INVALIDE, act->check(st));
+    EXPECT_EQ(POSITION_INVALIDE, act->check(*st));
     EXPECT_EQ(INTERDIT, st->get_cell_type({0, 0}));
     delete act;
 }
@@ -24,21 +24,21 @@ TEST_F(ActionTest, Ameliorer_EmptyCell)
     ActionConstruire act(TEST_EMPTY_CELL, PLAYER_1);
     ActionAmeliorer act2(TEST_EMPTY_CELL, PLAYER_1);
 
-    EXPECT_EQ(OK, act.check(st));
+    EXPECT_EQ(OK, act.check(*st));
     EXPECT_EQ(VIDE, st->get_cell_type(TEST_EMPTY_CELL));
-    act.apply_on(st);
-    EXPECT_EQ(OK, act2.check(st));
+    act.apply(st.get());
+    EXPECT_EQ(OK, act2.check(*st));
     EXPECT_EQ(TUYAU, st->get_cell_type(TEST_EMPTY_CELL));
-    act2.apply_on(st);
-    EXPECT_EQ(AMELIORATION_IMPOSSIBLE, act2.check(st));
+    act2.apply(st.get());
+    EXPECT_EQ(AMELIORATION_IMPOSSIBLE, act2.check(*st));
     EXPECT_EQ(SUPER_TUYAU, st->get_cell_type(TEST_EMPTY_CELL));
 }
 
 TEST_F(ActionTest, Ameliorer_NotEnoughActionPoints)
 {
-    set_points(st, COUT_AMELIORATION - 1);
+    set_points(st.get(), COUT_AMELIORATION - 1);
     ActionConstruire act(TEST_EMPTY_CELL, PLAYER_1);
     ActionAmeliorer act2(TEST_EMPTY_CELL, PLAYER_1);
 
-    EXPECT_EQ(PA_INSUFFISANTS, act.check(st));
+    EXPECT_EQ(PA_INSUFFISANTS, act.check(*st));
 }

--- a/src/tests/test-action_construire.cc
+++ b/src/tests/test-action_construire.cc
@@ -7,42 +7,42 @@
 TEST_F(ActionTest, Construire_InvalidPosition)
 {
     ActionConstruire act({0, 0}, PLAYER_1);
-    EXPECT_EQ(POSITION_INVALIDE, act.check(st));
+    EXPECT_EQ(POSITION_INVALIDE, act.check(*st));
 }
 
 TEST_F(ActionTest, Construire_ConstructionImpossible)
 {
     // players shouldn't be able to build pipes on bases
     ActionConstruire act(TEST_BASE, PLAYER_1);
-    EXPECT_EQ(CONSTRUCTION_IMPOSSIBLE, act.check(st));
+    EXPECT_EQ(CONSTRUCTION_IMPOSSIBLE, act.check(*st));
     EXPECT_EQ(BASE, st->get_cell_type(TEST_BASE));
 
     // players shouldn't be able to build pipes on pulsars
     ActionConstruire act2(TEST_PULSAR_POSITION, PLAYER_1);
-    EXPECT_EQ(CONSTRUCTION_IMPOSSIBLE, act2.check(st));
+    EXPECT_EQ(CONSTRUCTION_IMPOSSIBLE, act2.check(*st));
     EXPECT_EQ(PULSAR, st->get_cell_type(TEST_PULSAR_POSITION));
 }
 
 TEST_F(ActionTest, Construire_Ok)
 {
     ActionConstruire act(TEST_EMPTY_CELL, PLAYER_1);
-    EXPECT_EQ(OK, act.check(st));
+    EXPECT_EQ(OK, act.check(*st));
     EXPECT_EQ(VIDE, st->get_cell_type(TEST_EMPTY_CELL));
 
-    act.apply_on(st);
+    act.apply(st.get());
 
     EXPECT_EQ(TUYAU, st->get_cell_type(TEST_EMPTY_CELL));
 
     // players shouldn't be able to build pipes on pipes
-    EXPECT_EQ(CONSTRUCTION_IMPOSSIBLE, act.check(st));
+    EXPECT_EQ(CONSTRUCTION_IMPOSSIBLE, act.check(*st));
 }
 
 TEST_F(ActionTest, Construire_NoMoreActionPoints)
 {
-    set_points(st, COUT_CONSTRUCTION - 1);
+    set_points(st.get(), COUT_CONSTRUCTION - 1);
     ActionConstruire act({1, 1}, PLAYER_1);
 
-    EXPECT_EQ(PA_INSUFFISANTS, act.check(st));
+    EXPECT_EQ(PA_INSUFFISANTS, act.check(*st));
 }
 
 // Set a given number of action points to a given player

--- a/src/tests/test-action_deblayer.cc
+++ b/src/tests/test-action_deblayer.cc
@@ -7,10 +7,10 @@
 TEST_F(ActionTest, Deblayer_InvalidCell)
 {
     ActionDeblayer act(TEST_PULSAR_POSITION, PLAYER_1);
-    EXPECT_EQ(PAS_DE_DEBRIS, act.check(st));
+    EXPECT_EQ(PAS_DE_DEBRIS, act.check(*st));
 
     ActionDeblayer act2({0, 0}, PLAYER_1);
-    EXPECT_EQ(POSITION_INVALIDE, act2.check(st));
+    EXPECT_EQ(POSITION_INVALIDE, act2.check(*st));
 }
 
 TEST_F(ActionTest, Deblayer_Ok)
@@ -22,7 +22,7 @@ TEST_F(ActionTest, Deblayer_Ok)
     st->reset_action_points();
 
     ActionDeblayer act({1, 1}, PLAYER_1);
-    EXPECT_EQ(OK, act.check(st));
+    EXPECT_EQ(OK, act.check(*st));
 }
 
 TEST_F(ActionTest, Deblayer_NotEnoughActionPoints)
@@ -33,8 +33,8 @@ TEST_F(ActionTest, Deblayer_NotEnoughActionPoints)
     st->destroy_pipe({1, 1});
     st->reset_action_points();
 
-    set_points(st, COUT_DEBLAYAGE - 1);
+    set_points(st.get(), COUT_DEBLAYAGE - 1);
 
     ActionDeblayer act({1, 1}, PLAYER_1);
-    EXPECT_EQ(PA_INSUFFISANTS, act.check(st));
+    EXPECT_EQ(PA_INSUFFISANTS, act.check(*st));
 }

--- a/src/tests/test-action_deplacer_aspiration.cc
+++ b/src/tests/test-action_deplacer_aspiration.cc
@@ -7,22 +7,22 @@
 TEST_F(ActionTest, DeplacerAspiration_InvalidPosition)
 {
     ActionDeplacerAspiration act(TEST_BASE, {1, 1}, PLAYER_1);
-    EXPECT_EQ(PAS_DANS_BASE, act.check(st));
+    EXPECT_EQ(PAS_DANS_BASE, act.check(*st));
 
     ActionDeplacerAspiration act2({1, 1}, TEST_BASE, PLAYER_1);
-    EXPECT_EQ(PAS_DANS_BASE, act2.check(st));
+    EXPECT_EQ(PAS_DANS_BASE, act2.check(*st));
 
     ActionDeplacerAspiration act3(TEST_BASE, TEST_BASE, PLAYER_2);
-    EXPECT_EQ(DEPLACEMENT_INVALIDE, act3.check(st));
+    EXPECT_EQ(DEPLACEMENT_INVALIDE, act3.check(*st));
 
     ActionDeplacerAspiration act4(TEST_BASE, TEST_BASE_ALT, PLAYER_2);
-    EXPECT_EQ(PAS_DANS_BASE, act4.check(st));
+    EXPECT_EQ(PAS_DANS_BASE, act4.check(*st));
 }
 
 TEST_F(ActionTest, DeplacerAspiration_Ok)
 {
     ActionDeplacerAspiration act(TEST_BASE, TEST_BASE_ALT, PLAYER_1);
-    EXPECT_EQ(OK, act.check(st));
+    EXPECT_EQ(OK, act.check(*st));
 }
 
 TEST_F(ActionTest, DeplacerAspiration_ActionPoints)
@@ -30,26 +30,26 @@ TEST_F(ActionTest, DeplacerAspiration_ActionPoints)
     ActionDeplacerAspiration act(TEST_BASE, TEST_BASE_ALT, PLAYER_1);
     ActionDeplacerAspiration act2(TEST_BASE_ALT, TEST_BASE, PLAYER_1);
 
-    set_points(st, COUT_MODIFICATION_ASPIRATION);
-    EXPECT_EQ(OK, act.check(st));
+    set_points(st.get(), COUT_MODIFICATION_ASPIRATION);
+    EXPECT_EQ(OK, act.check(*st));
 
     // first move should be free
     unsigned orig_action_points = st->get_action_points();
-    act.apply_on(st);
+    act.apply(st.get());
     EXPECT_EQ(orig_action_points, st->get_action_points());
 
-    set_points(st, COUT_MODIFICATION_ASPIRATION - 1);
-    EXPECT_EQ(PA_INSUFFISANTS, act2.check(st));
-    act2.apply_on(st);
+    set_points(st.get(), COUT_MODIFICATION_ASPIRATION - 1);
+    EXPECT_EQ(PA_INSUFFISANTS, act2.check(*st));
+    act2.apply(st.get());
 
     for (unsigned i = 0; i < st->get_vacuum(TEST_BASE); i++)
     {
-        set_points(st, COUT_MODIFICATION_ASPIRATION);
-        EXPECT_EQ(OK, act.check(st));
-        act.apply_on(st);
+        set_points(st.get(), COUT_MODIFICATION_ASPIRATION);
+        EXPECT_EQ(OK, act.check(*st));
+        act.apply(st.get());
         EXPECT_EQ((unsigned)0, st->get_action_points());
     }
-    EXPECT_EQ(PUISSANCE_INSUFFISANTE, act.check(st));
+    EXPECT_EQ(PUISSANCE_INSUFFISANTE, act.check(*st));
 }
 
 TEST_F(ActionTest, DeplacerAspiration_AspirationLimit)
@@ -62,13 +62,13 @@ TEST_F(ActionTest, DeplacerAspiration_AspirationLimit)
         source_base = {N / 2 - 3 + i, 0};
         st->reset_action_points();
         ActionDeplacerAspiration act(source_base, destination_base, PLAYER_1);
-        EXPECT_EQ(OK, act.check(st));
-        act.apply_on(st);
+        EXPECT_EQ(OK, act.check(*st));
+        act.apply(st.get());
     }
     source_base = {N / 2 - 3 + LIMITE_ASPIRATION, 0};
     st->reset_action_points();
     ActionDeplacerAspiration act2(source_base, destination_base, PLAYER_1);
     EXPECT_EQ(LIMITE_ASPIRATION, (int)st->get_vacuum(destination_base));
-    EXPECT_EQ(LIMITE_ASPIRATION_ATTEINTE, act2.check(st));
+    EXPECT_EQ(LIMITE_ASPIRATION_ATTEINTE, act2.check(*st));
     EXPECT_EQ(LIMITE_ASPIRATION, (int)st->get_vacuum(destination_base));
 }

--- a/src/tests/test-action_detruire.cc
+++ b/src/tests/test-action_detruire.cc
@@ -9,16 +9,16 @@ TEST_F(ActionTest, Detruire_PipeCell)
     ActionDetruire act_destroy({1, 1}, PLAYER_1);
 
     // Not possible to destroy if there's no pipe
-    EXPECT_EQ(DESTRUCTION_IMPOSSIBLE, act_destroy.check(st));
+    EXPECT_EQ(DESTRUCTION_IMPOSSIBLE, act_destroy.check(*st));
 
     st->build_pipe({1, 1}, PLAYER_1);
     st->reset_action_points();
 
     // Not possible to destroy without enough plasma
-    EXPECT_EQ(CHARGE_INSUFFISANTE, act_destroy.check(st));
+    EXPECT_EQ(CHARGE_INSUFFISANTE, act_destroy.check(*st));
 
     st->decrease_plasma(PLAYER_1, -CHARGE_DESTRUCTION);
-    EXPECT_EQ(OK, act_destroy.check(st));
+    EXPECT_EQ(OK, act_destroy.check(*st));
 }
 
 TEST_F(ActionTest, Detruire_SuperPipeCell)
@@ -27,19 +27,19 @@ TEST_F(ActionTest, Detruire_SuperPipeCell)
     st->decrease_plasma(PLAYER_1, -CHARGE_DESTRUCTION);
 
     ActionAmeliorer act({1, 1}, PLAYER_1);
-    EXPECT_EQ(OK, act.check(st));
-    act.apply_on(st);
+    EXPECT_EQ(OK, act.check(*st));
+    act.apply(st.get());
 
     // Not possible to destroy a super-pipe with less than 40 points
     ActionDetruire act_destroy({1, 1}, PLAYER_1);
-    EXPECT_EQ(PA_INSUFFISANTS, act_destroy.check(st));
+    EXPECT_EQ(PA_INSUFFISANTS, act_destroy.check(*st));
 
     st->reset_action_points();
-    EXPECT_EQ(OK, act_destroy.check(st));
+    EXPECT_EQ(OK, act_destroy.check(*st));
 
     // Check that there's no points left after performing a destruction of a
     // super-pipe
-    act_destroy.apply_on(st);
+    act_destroy.apply(st.get());
     EXPECT_EQ(NB_POINTS_ACTION - COUT_DESTRUCTION_SUPER_TUYAU,
               (int)st->get_action_points());
 }
@@ -50,17 +50,17 @@ TEST_F(ActionTest, Detruire_BrokenPipeCell)
     st->decrease_plasma(PLAYER_1, -CHARGE_DESTRUCTION);
 
     ActionDetruire act_destroy({1, 1}, PLAYER_1);
-    EXPECT_EQ(OK, act_destroy.check(st));
-    act_destroy.apply_on(st);
+    EXPECT_EQ(OK, act_destroy.check(*st));
+    act_destroy.apply(st.get());
 
     // Not possible to destroy a pipe already broken
     st->reset_action_points();
-    EXPECT_EQ(DESTRUCTION_IMPOSSIBLE, act_destroy.check(st));
+    EXPECT_EQ(DESTRUCTION_IMPOSSIBLE, act_destroy.check(*st));
 }
 
 TEST_F(ActionTest, Detruire_InvalidPosition)
 {
     // Not possible to destroy anything out of the map
     ActionDetruire act_destroy({0, 0}, PLAYER_1);
-    EXPECT_EQ(POSITION_INVALIDE, act_destroy.check(st));
+    EXPECT_EQ(POSITION_INVALIDE, act_destroy.check(*st));
 }

--- a/src/tests/test-api.cc
+++ b/src/tests/test-api.cc
@@ -25,159 +25,195 @@
 
 TEST_F(ApiTest, Api_TypeCase)
 {
-    EXPECT_EQ(VIDE, players[0].api->type_case({1, 1}));
-    st->build_pipe({1, 1}, players[0].id);
-    EXPECT_EQ(TUYAU, players[0].api->type_case({1, 1}));
-    st->upgrade_pipe({1, 1}, players[0].id);
-    EXPECT_EQ(SUPER_TUYAU, players[0].api->type_case({1, 1}));
-    st->destroy_pipe({1, 1});
-    EXPECT_EQ(DEBRIS, players[0].api->type_case({1, 1}));
-    st->clear_rubble({1, 1});
-    EXPECT_EQ(VIDE, players[0].api->type_case({1, 1}));
+    for (auto& player : players)
+    {
+        EXPECT_EQ(VIDE, player.api->type_case({1, 1}));
+        st(player)->build_pipe({1, 1}, player.id);
+        EXPECT_EQ(TUYAU, player.api->type_case({1, 1}));
+        st(player)->upgrade_pipe({1, 1}, player.id);
+        EXPECT_EQ(SUPER_TUYAU, player.api->type_case({1, 1}));
+        st(player)->destroy_pipe({1, 1});
+        EXPECT_EQ(DEBRIS, player.api->type_case({1, 1}));
+        st(player)->clear_rubble({1, 1});
+        EXPECT_EQ(VIDE, player.api->type_case({1, 1}));
 
-    EXPECT_EQ(INTERDIT, players[0].api->type_case({0, 1}));
-    EXPECT_EQ(BASE, players[0].api->type_case({0, TAILLE_TERRAIN / 2}));
+        EXPECT_EQ(INTERDIT, player.api->type_case({0, 1}));
+        EXPECT_EQ(BASE, player.api->type_case({0, TAILLE_TERRAIN / 2}));
+    }
 }
 
 TEST_F(ApiTest, Api_ListePulsars)
 {
-    std::vector<position> expected;
-    expected.push_back(TEST_PULSAR_POSITION);
-    EXPECT_EQ(expected, players[0].api->liste_pulsars());
+    for (auto& player : players)
+    {
+        std::vector<position> expected;
+        expected.push_back(TEST_PULSAR_POSITION);
+        EXPECT_EQ(expected, player.api->liste_pulsars());
+    }
 }
 
 TEST_F(ApiTest, Api_ListePlasmas)
 {
-    std::vector<position> expected;
-    EXPECT_EQ(expected, players[0].api->liste_plasmas());
-    for (int i = 1; i < TEST_PULSAR_POSITION.x; ++i)
-        st->build_pipe({i, TEST_PULSAR_POSITION.y}, players[0].id);
-    auto pulsar = st->get_pulsar(TEST_PULSAR_POSITION);
-    while ((int)st->get_turn() != pulsar.periode)
-        st->increment_turn();
-    st->emit_plasma();
-    position pos{TEST_PULSAR_POSITION.x - 1, TEST_PULSAR_POSITION.y};
-    expected.push_back(pos);
-    EXPECT_TRUE(std::is_permutation(expected.begin(), expected.end(),
-                                    players[0].api->liste_plasmas().begin()));
-    st->build_pipe({pos.x, pos.y - 1}, players[0].id);
-    st->build_pipe({pos.x + 1, pos.y - 1}, players[0].id);
-    st->reset_board_distances();
-    st->emit_plasma();
-    expected.push_back({pos.x + 1, pos.y - 1});
-    EXPECT_TRUE(std::is_permutation(expected.begin(), expected.end(),
-                                    players[0].api->liste_plasmas().begin()));
+    for (auto& player : players)
+    {
+        std::vector<position> expected;
+        EXPECT_EQ(expected, player.api->liste_plasmas());
+        for (int i = 1; i < TEST_PULSAR_POSITION.x; ++i)
+            st(player)->build_pipe({i, TEST_PULSAR_POSITION.y}, player.id);
+        auto pulsar = st(player)->get_pulsar(TEST_PULSAR_POSITION);
+        while ((int)st(player)->get_turn() != pulsar.periode)
+            st(player)->increment_turn();
+        st(player)->emit_plasma();
+        position pos{TEST_PULSAR_POSITION.x - 1, TEST_PULSAR_POSITION.y};
+        expected.push_back(pos);
+        EXPECT_TRUE(std::is_permutation(expected.begin(), expected.end(),
+                                        player.api->liste_plasmas().begin()));
+        st(player)->build_pipe({pos.x, pos.y - 1}, player.id);
+        st(player)->build_pipe({pos.x + 1, pos.y - 1}, player.id);
+        st(player)->reset_board_distances();
+        st(player)->emit_plasma();
+        expected.push_back({pos.x + 1, pos.y - 1});
+        EXPECT_TRUE(std::is_permutation(expected.begin(), expected.end(),
+                                        player.api->liste_plasmas().begin()));
+    }
 }
 
 TEST_F(ApiTest, Api_ListeTuyaux)
 {
-    std::vector<position> expected;
-    EXPECT_EQ(expected, players[0].api->liste_tuyaux());
-    auto build = [&](position pos) {
-        st->build_pipe(pos, players[0].id);
-        expected.push_back(pos);
-        EXPECT_TRUE(
-            std::is_permutation(expected.begin(), expected.end(),
-                                players[0].api->liste_tuyaux().begin()));
-    };
-    build({1, 1});
-    build({2, 1});
-    build({1, 2});
+    for (auto& player : players)
+    {
+        std::vector<position> expected;
+        EXPECT_EQ(expected, player.api->liste_tuyaux());
+        auto build = [&](position pos) {
+            st(player)->build_pipe(pos, player.id);
+            expected.push_back(pos);
+            EXPECT_TRUE(
+                std::is_permutation(expected.begin(), expected.end(),
+                                    player.api->liste_tuyaux().begin()));
+        };
+        build({1, 1});
+        build({2, 1});
+        build({1, 2});
+    }
 }
 
 TEST_F(ApiTest, Api_ListeSuperTuyaux)
 {
-    std::vector<position> expected;
-    EXPECT_EQ(expected, players[0].api->liste_super_tuyaux());
-    auto build_upgrade = [&](position pos) {
-        st->build_pipe(pos, players[0].id);
-        EXPECT_TRUE(
-            std::is_permutation(expected.begin(), expected.end(),
-                                players[0].api->liste_super_tuyaux().begin()));
-        st->upgrade_pipe(pos, players[0].id);
-        expected.push_back(pos);
-        EXPECT_TRUE(
-            std::is_permutation(expected.begin(), expected.end(),
-                                players[0].api->liste_super_tuyaux().begin()));
-    };
-    build_upgrade({1, 1});
-    build_upgrade({2, 1});
-    build_upgrade({1, 2});
+    for (auto& player : players)
+    {
+        std::vector<position> expected;
+        EXPECT_EQ(expected, player.api->liste_super_tuyaux());
+        auto build_upgrade = [&](position pos) {
+            st(player)->build_pipe(pos, player.id);
+            EXPECT_TRUE(
+                std::is_permutation(expected.begin(), expected.end(),
+                                    player.api->liste_super_tuyaux().begin()));
+            st(player)->upgrade_pipe(pos, player.id);
+            expected.push_back(pos);
+            EXPECT_TRUE(
+                std::is_permutation(expected.begin(), expected.end(),
+                                    player.api->liste_super_tuyaux().begin()));
+        };
+        build_upgrade({1, 1});
+        build_upgrade({2, 1});
+        build_upgrade({1, 2});
+    }
 }
 
 TEST_F(ApiTest, Api_ListeDebris)
 {
-    std::vector<position> expected;
-    EXPECT_EQ(expected, players[0].api->liste_debris());
-    auto build_destroy = [&](position pos) {
-        st->build_pipe(pos, players[0].id);
-        EXPECT_TRUE(
-            std::is_permutation(expected.begin(), expected.end(),
-                                players[0].api->liste_debris().begin()));
-        st->destroy_pipe(pos);
-        expected.push_back(pos);
-        EXPECT_TRUE(
-            std::is_permutation(expected.begin(), expected.end(),
-                                players[0].api->liste_debris().begin()));
-    };
-    build_destroy({1, 1});
-    build_destroy({2, 1});
-    build_destroy({1, 2});
+    for (auto& player : players)
+    {
+        std::vector<position> expected;
+        EXPECT_EQ(expected, player.api->liste_debris());
+        auto build_destroy = [&](position pos) {
+            st(player)->build_pipe(pos, player.id);
+            EXPECT_TRUE(
+                std::is_permutation(expected.begin(), expected.end(),
+                                    player.api->liste_debris().begin()));
+            st(player)->destroy_pipe(pos);
+            expected.push_back(pos);
+            EXPECT_TRUE(
+                std::is_permutation(expected.begin(), expected.end(),
+                                    player.api->liste_debris().begin()));
+        };
+        build_destroy({1, 1});
+        build_destroy({2, 1});
+        build_destroy({1, 2});
+    }
 }
 
 TEST_F(ApiTest, Api_EstPulsar)
 {
-    EXPECT_FALSE(players[0].api->est_pulsar({1, 1}));
-    EXPECT_TRUE(players[0].api->est_pulsar(TEST_PULSAR_POSITION));
+    for (auto& player : players)
+    {
+        EXPECT_FALSE(player.api->est_pulsar({1, 1}));
+        EXPECT_TRUE(player.api->est_pulsar(TEST_PULSAR_POSITION));
+    }
 }
 
 TEST_F(ApiTest, Api_EstTuyau)
 {
-    EXPECT_FALSE(players[0].api->est_tuyau({1, 1}));
-    st->build_pipe({1, 1}, players[0].id);
-    EXPECT_TRUE(players[0].api->est_tuyau({1, 1}));
-    st->upgrade_pipe({1, 1}, players[0].id);
-    EXPECT_TRUE(players[0].api->est_tuyau({1, 1}));
+    for (auto& player : players)
+    {
+        EXPECT_FALSE(player.api->est_tuyau({1, 1}));
+        st(player)->build_pipe({1, 1}, player.id);
+        EXPECT_TRUE(player.api->est_tuyau({1, 1}));
+        st(player)->upgrade_pipe({1, 1}, player.id);
+        EXPECT_TRUE(player.api->est_tuyau({1, 1}));
+    }
 }
 
 TEST_F(ApiTest, Api_EstSimpleTuyau)
 {
-    EXPECT_FALSE(players[0].api->est_simple_tuyau({1, 1}));
-    st->build_pipe({1, 1}, players[0].id);
-    EXPECT_TRUE(players[0].api->est_simple_tuyau({1, 1}));
-    st->upgrade_pipe({1, 1}, players[0].id);
-    EXPECT_FALSE(players[0].api->est_simple_tuyau({1, 1}));
+    for (auto& player : players)
+    {
+        EXPECT_FALSE(player.api->est_simple_tuyau({1, 1}));
+        st(player)->build_pipe({1, 1}, player.id);
+        EXPECT_TRUE(player.api->est_simple_tuyau({1, 1}));
+        st(player)->upgrade_pipe({1, 1}, player.id);
+        EXPECT_FALSE(player.api->est_simple_tuyau({1, 1}));
+    }
 }
 
 TEST_F(ApiTest, Api_EstSuperTuyau)
 {
-    EXPECT_FALSE(players[0].api->est_super_tuyau({1, 1}));
-    st->build_pipe({1, 1}, players[0].id);
-    EXPECT_FALSE(players[0].api->est_super_tuyau({1, 1}));
-    st->upgrade_pipe({1, 1}, players[0].id);
-    EXPECT_TRUE(players[0].api->est_super_tuyau({1, 1}));
+    for (auto& player : players)
+    {
+        EXPECT_FALSE(player.api->est_super_tuyau({1, 1}));
+        st(player)->build_pipe({1, 1}, player.id);
+        EXPECT_FALSE(player.api->est_super_tuyau({1, 1}));
+        st(player)->upgrade_pipe({1, 1}, player.id);
+        EXPECT_TRUE(player.api->est_super_tuyau({1, 1}));
+    }
 }
 
 TEST_F(ApiTest, Api_EstDebris)
 {
-    EXPECT_FALSE(players[0].api->est_debris({1, 1}));
-    st->build_pipe({1, 1}, players[0].id);
-    EXPECT_FALSE(players[0].api->est_debris({1, 1}));
-    st->destroy_pipe({1, 1});
-    EXPECT_TRUE(players[0].api->est_debris({1, 1}));
+    for (auto& player : players)
+    {
+        EXPECT_FALSE(player.api->est_debris({1, 1}));
+        st(player)->build_pipe({1, 1}, player.id);
+        EXPECT_FALSE(player.api->est_debris({1, 1}));
+        st(player)->destroy_pipe({1, 1});
+        EXPECT_TRUE(player.api->est_debris({1, 1}));
+    }
 }
 
 TEST_F(ApiTest, Api_EstLibre)
 {
-    EXPECT_TRUE(players[0].api->est_libre({1, 1}));
-    EXPECT_FALSE(players[0].api->est_libre({0, TAILLE_TERRAIN / 2}));
-    st->build_pipe({1, 1}, players[0].id);
-    EXPECT_FALSE(players[0].api->est_libre({1, 1}));
+    for (auto& player : players)
+    {
+        EXPECT_TRUE(player.api->est_libre({1, 1}));
+        EXPECT_FALSE(player.api->est_libre({0, TAILLE_TERRAIN / 2}));
+        st(player)->build_pipe({1, 1}, player.id);
+        EXPECT_FALSE(player.api->est_libre({1, 1}));
+    }
 }
 
 TEST_F(ApiTest, Api_InfoPulsar)
 {
-    auto pulsar = st->get_pulsar(TEST_PULSAR_POSITION);
+    auto pulsar = st(players[0])->get_pulsar(TEST_PULSAR_POSITION);
     for (auto& player : players)
     {
         auto p = player.api->info_pulsar(TEST_PULSAR_POSITION);
@@ -190,26 +226,33 @@ TEST_F(ApiTest, Api_InfoPulsar)
 
 TEST_F(ApiTest, Api_ChargesPresentes)
 {
-    for (int i = 1; i < TEST_PULSAR_POSITION.x; ++i)
-        st->build_pipe({i, TEST_PULSAR_POSITION.y}, players[0].id);
-    auto pulsar = st->get_pulsar(TEST_PULSAR_POSITION);
-    while ((int)st->get_turn() != pulsar.periode)
-        st->increment_turn();
-    position pos{TEST_PULSAR_POSITION.x - 1, TEST_PULSAR_POSITION.y};
-    EXPECT_EQ(0, players[0].api->charges_presentes(pos));
-    st->emit_plasma();
-    EXPECT_EQ(pulsar.puissance, players[0].api->charges_presentes(pos));
+    for (auto& player : players)
+    {
+        for (int i = 1; i < TEST_PULSAR_POSITION.x; ++i)
+            st(player)->build_pipe({i, TEST_PULSAR_POSITION.y}, player.id);
+        auto pulsar = st(player)->get_pulsar(TEST_PULSAR_POSITION);
+        while ((int)st(player)->get_turn() != pulsar.periode)
+            st(player)->increment_turn();
+        position pos{TEST_PULSAR_POSITION.x - 1, TEST_PULSAR_POSITION.y};
+        EXPECT_EQ(0, player.api->charges_presentes(pos));
+        st(player)->emit_plasma();
+        EXPECT_EQ(pulsar.puissance, player.api->charges_presentes(pos));
+    }
 }
 
 TEST_F(ApiTest, Api_ConstructeurTuyau)
 {
-    const auto& api = players[0].api;
-    st->build_pipe({1, 1}, players[0].id);
-    EXPECT_EQ(players[0].id, api->constructeur_tuyau({1, 1}));
-    st->build_pipe({4, 2}, players[1].id);
-    EXPECT_EQ(players[1].id, api->constructeur_tuyau({4, 2}));
-    st->upgrade_pipe({4, 2}, players[0].id);
-    EXPECT_EQ(players[0].id, api->constructeur_tuyau({4, 2}));
+    for (size_t player_index : {0, 1})
+    {
+        auto& player = players[player_index];
+        auto& other_player = players[1 - player_index];
+        st(player)->build_pipe({1, 1}, player.id);
+        EXPECT_EQ(player.id, player.api->constructeur_tuyau({1, 1}));
+        st(player)->build_pipe({4, 2}, other_player.id);
+        EXPECT_EQ(other_player.id, player.api->constructeur_tuyau({4, 2}));
+        st(player)->upgrade_pipe({4, 2}, player.id);
+        EXPECT_EQ(player.id, player.api->constructeur_tuyau({4, 2}));
+    }
 }
 
 TEST_F(ApiTest, Api_ProprietaireBase)
@@ -247,65 +290,72 @@ TEST_F(ApiTest, Api_BasesListes)
 
 TEST_F(ApiTest, Api_PuissanceApiration)
 {
-    for (int i = 0; i < TAILLE_TERRAIN; ++i)
+    for (auto& player : players)
     {
-        int p = i >= TAILLE_TERRAIN / 3 && i < TAILLE_TERRAIN * 2 / 3 ? 1 : -1;
-        EXPECT_EQ(p, players[0].api->puissance_aspiration({0, i}));
+        for (int i = 0; i < TAILLE_TERRAIN; ++i)
+        {
+            int p =
+                i >= TAILLE_TERRAIN / 3 && i < TAILLE_TERRAIN * 2 / 3 ? 1 : -1;
+            EXPECT_EQ(p, player.api->puissance_aspiration({0, i}));
+        }
+        position pos{TAILLE_TERRAIN / 2, 0};
+        EXPECT_EQ(1, player.api->puissance_aspiration(pos));
+        st(player)->increment_vacuum(pos);
+        EXPECT_EQ(2, player.api->puissance_aspiration(pos));
+        st(player)->increment_vacuum(pos);
+        EXPECT_EQ(3, player.api->puissance_aspiration(pos));
+        pos.x += 1;
+        EXPECT_EQ(1, player.api->puissance_aspiration(pos));
     }
-    position pos{TAILLE_TERRAIN / 2, 0};
-    EXPECT_EQ(1, players[0].api->puissance_aspiration(pos));
-    st->increment_vacuum(pos);
-    EXPECT_EQ(2, players[0].api->puissance_aspiration(pos));
-    st->increment_vacuum(pos);
-    EXPECT_EQ(3, players[0].api->puissance_aspiration(pos));
-    pos.x += 1;
-    EXPECT_EQ(1, players[0].api->puissance_aspiration(pos));
 }
 
 TEST_F(ApiTest, Api_DirectionsPlasma)
 {
-    position pos{1, TAILLE_TERRAIN / 2};
-    std::vector<position> expected;
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_CONSTRUCTION);
-    players[0].api->construire(pos);
-    expected.push_back({0, TAILLE_TERRAIN / 2});
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_CONSTRUCTION);
-    players[0].api->construire({pos.x, pos.y + 1});
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
+    for (auto& player : players)
+    {
+        position pos{1, TAILLE_TERRAIN / 2};
+        std::vector<position> expected;
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_CONSTRUCTION);
+        player.api->construire(pos);
+        expected.push_back({0, TAILLE_TERRAIN / 2});
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_CONSTRUCTION);
+        player.api->construire({pos.x, pos.y + 1});
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
 
-    expected.clear();
-    pos = position{TAILLE_TERRAIN - 3, TAILLE_TERRAIN / 2};
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_CONSTRUCTION);
-    players[0].api->construire(pos);
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_CONSTRUCTION);
-    players[0].api->construire({pos.x, pos.y + 1});
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_CONSTRUCTION);
-    players[0].api->construire({pos.x + 1, pos.y + 1});
-    expected.push_back({pos.x, pos.y + 1});
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_CONSTRUCTION);
-    players[0].api->construire({pos.x, pos.y - 1});
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_CONSTRUCTION);
-    DEBUG("%d\n", players[0].api->est_tuyau({pos.x + 1, pos.y - 1}));
-    players[0].api->construire({pos.x + 1, pos.y - 1});
-    expected.push_back({pos.x, pos.y - 1});
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_DESTRUCTION);
-    st->decrease_plasma(players[0].id, -CHARGE_DESTRUCTION);
-    players[0].api->detruire({pos.x, pos.y - 1});
-    expected.pop_back();
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
-    set_points(st, COUT_CONSTRUCTION);
-    players[0].api->construire({pos.x + 1, pos.y});
-    expected.clear();
-    expected.push_back({pos.x + 1, pos.y});
-    EXPECT_EQ(expected, players[0].api->directions_plasma(pos));
+        expected.clear();
+        pos = position{TAILLE_TERRAIN - 3, TAILLE_TERRAIN / 2};
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_CONSTRUCTION);
+        player.api->construire(pos);
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_CONSTRUCTION);
+        player.api->construire({pos.x, pos.y + 1});
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_CONSTRUCTION);
+        player.api->construire({pos.x + 1, pos.y + 1});
+        expected.push_back({pos.x, pos.y + 1});
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_CONSTRUCTION);
+        player.api->construire({pos.x, pos.y - 1});
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_CONSTRUCTION);
+        DEBUG("%d\n", player.api->est_tuyau({pos.x + 1, pos.y - 1}));
+        player.api->construire({pos.x + 1, pos.y - 1});
+        expected.push_back({pos.x, pos.y - 1});
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_DESTRUCTION);
+        st(player)->decrease_plasma(player.id, -CHARGE_DESTRUCTION);
+        player.api->detruire({pos.x, pos.y - 1});
+        expected.pop_back();
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+        set_points(st(player), COUT_CONSTRUCTION);
+        player.api->construire({pos.x + 1, pos.y});
+        expected.clear();
+        expected.push_back({pos.x + 1, pos.y});
+        EXPECT_EQ(expected, player.api->directions_plasma(pos));
+    }
 }
 
 TEST_F(ApiTest, Api_CoutProchaineModificationAspiration)
@@ -313,16 +363,16 @@ TEST_F(ApiTest, Api_CoutProchaineModificationAspiration)
     for (auto& player : players)
     {
         EXPECT_EQ(0, player.api->cout_prochaine_modification_aspiration());
-        st->set_vacuum_moved(true);
+        st(player)->set_vacuum_moved(true);
         EXPECT_EQ(COUT_MODIFICATION_ASPIRATION,
                   player.api->cout_prochaine_modification_aspiration());
-        st->set_vacuum_moved(false);
+        st(player)->set_vacuum_moved(false);
         EXPECT_EQ(0, player.api->cout_prochaine_modification_aspiration());
         auto bases = player.api->ma_base();
         player.api->deplacer_aspiration(bases[0], bases[1]);
         EXPECT_EQ(COUT_MODIFICATION_ASPIRATION,
                   player.api->cout_prochaine_modification_aspiration());
-        st->set_vacuum_moved(false);
+        st(player)->set_vacuum_moved(false);
     }
 }
 
@@ -331,13 +381,14 @@ TEST_F(ApiTest, Api_HistTuyauxConstruits)
     for (int player_index : {0, 1})
     {
         auto& player = players[player_index];
-        auto& other = players[(player_index + 1) % 2];
+        auto& other = players[1 - player_index];
         std::vector<position> expected;
         EXPECT_EQ(expected, other.api->hist_tuyaux_construits());
         auto build = [&](position pos) {
-            set_points(st, COUT_CONSTRUCTION);
+            set_points(st(player), COUT_CONSTRUCTION);
             EXPECT_EQ(OK, player.api->construire(pos));
             expected.push_back(pos);
+            send_actions(&player, &other);
             EXPECT_EQ(expected, other.api->hist_tuyaux_construits());
         };
         build({1, 1 + player_index * 2});
@@ -351,16 +402,17 @@ TEST_F(ApiTest, Api_HistTuyauxDetruits)
     for (int player_index : {0, 1})
     {
         auto& player = players[player_index];
-        auto& other = players[(player_index + 1) % 2];
+        auto& other = players[1 - player_index];
         std::vector<position> expected;
         EXPECT_EQ(expected, other.api->hist_tuyaux_detruits());
         auto build_destroy = [&](position pos) {
-            set_points(st, COUT_CONSTRUCTION);
+            set_points(st(player), COUT_CONSTRUCTION);
             EXPECT_EQ(OK, player.api->construire(pos));
-            set_points(st, COUT_DESTRUCTION);
-            st->decrease_plasma(player.id, -CHARGE_DESTRUCTION);
+            set_points(st(player), COUT_DESTRUCTION);
+            st(player)->decrease_plasma(player.id, -CHARGE_DESTRUCTION);
             EXPECT_EQ(OK, player.api->detruire(pos));
             expected.push_back(pos);
+            send_actions(&player, &other);
             EXPECT_EQ(expected, other.api->hist_tuyaux_detruits());
         };
         build_destroy({1, 1 + player_index * 2});
@@ -374,15 +426,16 @@ TEST_F(ApiTest, Api_HistTuyauxAmeliores)
     for (int player_index : {0, 1})
     {
         auto& player = players[player_index];
-        auto& other = players[(player_index + 1) % 2];
+        auto& other = players[1 - player_index];
         std::vector<position> expected;
         EXPECT_EQ(expected, other.api->hist_tuyaux_ameliores());
         auto build_upgrade = [&](position pos) {
-            set_points(st, COUT_CONSTRUCTION);
+            set_points(st(player), COUT_CONSTRUCTION);
             EXPECT_EQ(OK, player.api->construire(pos));
-            set_points(st, COUT_AMELIORATION);
+            set_points(st(player), COUT_AMELIORATION);
             EXPECT_EQ(OK, player.api->ameliorer(pos));
             expected.push_back(pos);
+            send_actions(&player, &other);
             EXPECT_EQ(expected, other.api->hist_tuyaux_ameliores());
         };
         build_upgrade({1, 1 + player_index * 2});
@@ -396,18 +449,19 @@ TEST_F(ApiTest, Api_HistDebrisDeblayes)
     for (int player_index : {0, 1})
     {
         auto& player = players[player_index];
-        auto& other = players[(player_index + 1) % 2];
+        auto& other = players[1 - player_index];
         std::vector<position> expected;
         EXPECT_EQ(expected, other.api->hist_debris_deblayes());
         auto build_destroy_clear = [&](position pos) {
-            set_points(st, COUT_CONSTRUCTION);
+            set_points(st(player), COUT_CONSTRUCTION);
             EXPECT_EQ(OK, player.api->construire(pos));
-            set_points(st, COUT_DESTRUCTION);
-            st->decrease_plasma(player.id, -CHARGE_DESTRUCTION);
+            set_points(st(player), COUT_DESTRUCTION);
+            st(player)->decrease_plasma(player.id, -CHARGE_DESTRUCTION);
             EXPECT_EQ(OK, player.api->detruire(pos));
-            set_points(st, COUT_DEBLAYAGE);
+            set_points(st(player), COUT_DEBLAYAGE);
             EXPECT_EQ(OK, player.api->deblayer(pos));
             expected.push_back(pos);
+            send_actions(&player, &other);
             EXPECT_EQ(expected, other.api->hist_debris_deblayes());
         };
         build_destroy_clear({1, 1});
@@ -421,19 +475,19 @@ TEST_F(ApiTest, Api_HistPointAspirationAjoutes)
     for (int player_index : {0, 1})
     {
         auto& player = players[player_index];
-        auto& other = players[(player_index + 1) % 2];
+        auto& other = players[1 - player_index];
         std::vector<position> expected;
         EXPECT_EQ(expected, other.api->hist_points_aspiration_ajoutes());
         auto bases = player.api->ma_base();
-        auto move = [&](int base_id) {
-            set_points(st, COUT_MODIFICATION_ASPIRATION);
-            expected.push_back(bases[base_id]);
-            st->increment_vacuum(bases[0]); // let's cheat a bit
-            return player.api->deplacer_aspiration(bases[0], bases[base_id]);
+        auto move = [&](int base_src, int base_dst) {
+            set_points(st(player), COUT_MODIFICATION_ASPIRATION);
+            expected.push_back(bases[base_dst]);
+            return player.api->deplacer_aspiration(bases[base_src],
+                                                   bases[base_dst]);
         };
-        EXPECT_EQ(OK, move(1));
-        EXPECT_EQ(OK, move(2));
-        EXPECT_EQ(OK, move(5));
+        EXPECT_EQ(OK, move(1, 3));
+        EXPECT_EQ(OK, move(2, 4));
+        send_actions(&player, &other);
         EXPECT_EQ(expected, other.api->hist_points_aspiration_ajoutes());
     }
 }
@@ -443,12 +497,12 @@ TEST_F(ApiTest, Api_HistPointAspirationRetires)
     for (int player_index : {0, 1})
     {
         auto& player = players[player_index];
-        auto& other = players[(player_index + 1) % 2];
+        auto& other = players[1 - player_index];
         std::vector<position> expected;
         EXPECT_EQ(expected, other.api->hist_points_aspiration_retires());
         auto bases = player.api->ma_base();
         auto move = [&](int base_id, int to = 0) {
-            set_points(st, COUT_MODIFICATION_ASPIRATION);
+            set_points(st(player), COUT_MODIFICATION_ASPIRATION);
             expected.push_back(bases[base_id]);
             return player.api->deplacer_aspiration(bases[base_id], bases[to]);
         };
@@ -457,6 +511,7 @@ TEST_F(ApiTest, Api_HistPointAspirationRetires)
         EXPECT_EQ(OK, move(2));
         EXPECT_EQ(OK, move(5));
         EXPECT_EQ(OK, move(0, 1));
+        send_actions(&player, &other);
         EXPECT_EQ(expected, other.api->hist_points_aspiration_retires());
     }
 }
@@ -473,7 +528,7 @@ TEST_F(ApiTest, Api_Adversaire)
 {
     for (int player_index : {0, 1})
     {
-        int expected = players[(player_index + 1) % 2].id;
+        int expected = players[1 - player_index].id;
         EXPECT_EQ(expected, players[player_index].api->adversaire());
     }
 }
@@ -484,7 +539,7 @@ TEST_F(ApiTest, Api_PointsAction)
     {
         for (unsigned value : {0, 4, 10, 30, 40})
         {
-            set_points(st, value);
+            set_points(st(player), value);
             ASSERT_EQ(true, player.api->points_action() >= 0);
             EXPECT_EQ(value, (unsigned)player.api->points_action());
         }
@@ -500,7 +555,8 @@ TEST_F(ApiTest, Api_Score)
     };
     for (int player_index : {0, 1})
     {
-        PlayerInfo info = st->get_player_info().at(players[player_index].id);
+        auto& player = players[player_index];
+        PlayerInfo info = st(player)->get_player_info().at(player.id);
         check_score(0, player_index);
         info.collect_plasma(0.3);
         check_score(0, player_index);
@@ -524,8 +580,8 @@ TEST_F(ApiTest, Api_TourActuel)
         for (auto& player : players)
         {
             EXPECT_EQ(turn, player.api->tour_actuel());
+            st(player)->increment_turn();
         }
-        st->increment_turn();
     }
 }
 
@@ -536,7 +592,7 @@ TEST_F(ApiTest, Api_Annuler)
         EXPECT_FALSE(player.api->annuler());
         position pos{1, 1};
         EXPECT_TRUE(player.api->est_libre(pos));
-        set_points(st, COUT_CONSTRUCTION);
+        set_points(st(player), COUT_CONSTRUCTION);
         EXPECT_EQ(OK, player.api->construire(pos));
         EXPECT_TRUE(player.api->est_tuyau(pos));
         EXPECT_TRUE(player.api->annuler());

--- a/src/tests/test-api.cc
+++ b/src/tests/test-api.cc
@@ -589,13 +589,13 @@ TEST_F(ApiTest, Api_Annuler)
 {
     for (auto& player : players)
     {
-        EXPECT_FALSE(player.api->annuler());
+        EXPECT_FALSE(player.api->cancel());
         position pos{1, 1};
         EXPECT_TRUE(player.api->est_libre(pos));
         set_points(st(player), COUT_CONSTRUCTION);
         EXPECT_EQ(OK, player.api->construire(pos));
         EXPECT_TRUE(player.api->est_tuyau(pos));
-        EXPECT_TRUE(player.api->annuler());
+        EXPECT_TRUE(player.api->cancel());
         EXPECT_TRUE(player.api->est_libre(pos));
     }
 }

--- a/src/tests/test-dumper.cc
+++ b/src/tests/test-dumper.cc
@@ -29,7 +29,7 @@ TEST_F(RulesTest, DumpUnicodeString)
     std::ostringstream oss;
     std::string out;
     auto& player1_info =
-        rules->get_game_state()->get_player_info().find(PLAYER_ID_1)->second;
+        rules->get_game_state().get_player_info().find(PLAYER_ID_1)->second;
 
     player1_info.set_name("\xc3\xa9l\xc3\xa9phant"); // éléphant
     oss.str("");

--- a/src/tests/test-rules.cc
+++ b/src/tests/test-rules.cc
@@ -8,12 +8,12 @@ TEST_F(RulesTest, Rules_Finish)
     while (!rules->is_finished())
     {
         rules->start_of_player_turn(1);
-        EXPECT_EQ(turn, rules->get_game_state()->get_turn());
+        EXPECT_EQ(turn, rules->get_game_state().get_turn());
         ++turn;
         rules->end_of_player_turn(1);
         EXPECT_FALSE(rules->is_finished());
         rules->start_of_player_turn(2);
-        EXPECT_EQ(turn, rules->get_game_state()->get_turn());
+        EXPECT_EQ(turn, rules->get_game_state().get_turn());
         ++turn;
         rules->end_of_player_turn(2);
     }


### PR DESCRIPTION
* Remove GameStateWrapper, game state updates in tests is done using
  `send_actions`.
* Tests: test both players
* Tests: do not cheeat in `Api_HistPointAspirationAjoutes`, this is not
  possible now that the actions are checked in the opponent's game state when
  doing `send_actions`.
