### PR TITLE
enum: BASE -> BASE_JOUEUR

### DIFF
--- a/champions/bifore_cxx/dummy_ai.cc
+++ b/champions/bifore_cxx/dummy_ai.cc
@@ -87,7 +87,7 @@ void printMap(bool color) {
           case PULSAR:
             cout << "P";
             break;
-          case BASE:
+          case BASE_JOUEUR:
             cout << "B";
             break;
           case INTERDIT:
@@ -125,7 +125,7 @@ void printCase(int x, int y) {
     case PULSAR:
       cout << "1;37mP";
       break;
-    case BASE:
+    case BASE_JOUEUR:
       cout << "1;34mB";
       break;
     case INTERDIT:

--- a/champions/py_ai_bc/destruction_ai/prologin.py
+++ b/champions/py_ai_bc/destruction_ai/prologin.py
@@ -34,7 +34,7 @@ def print_map():
                 print('S', end = '', file = sys.stdout)
             elif c == api.case_type.PULSAR:
                 print('#', end = '', file = sys.stdout)
-            elif c == api.case_type.BASE:
+            elif c == api.case_type.BASE_JOUEUR:
                 print('B', end = '', file = sys.stdout)
             elif c == api.case_type.DEBRIS:
                 print('D', end = '', file = sys.stdout)

--- a/champions/py_ai_bc/dummy_ai/prologin.py
+++ b/champions/py_ai_bc/dummy_ai/prologin.py
@@ -25,7 +25,7 @@ def print_map():
                 print('S', end = '', file = sys.stderr)
             elif c == api.case_type.PULSAR:
                 print('#', end = '', file = sys.stderr)
-            elif c == api.case_type.BASE:
+            elif c == api.case_type.BASE_JOUEUR:
                 print('B', end = '', file = sys.stderr)
             elif c == api.case_type.DEBRIS:
                 print('D', end = '', file = sys.stderr)

--- a/champions/py_ai_bc/improved_ai/prologin.py
+++ b/champions/py_ai_bc/improved_ai/prologin.py
@@ -50,7 +50,7 @@ def print_map():
                 print('S', end = '', file = sys.stdout)
             elif c == api.case_type.PULSAR:
                 print('#', end = '', file = sys.stdout)
-            elif c == api.case_type.BASE:
+            elif c == api.case_type.BASE_JOUEUR:
                 print('B', end = '', file = sys.stdout)
             elif c == api.case_type.DEBRIS:
                 print('D', end = '', file = sys.stdout)

--- a/prologin2016.yml
+++ b/prologin2016.yml
@@ -115,7 +115,7 @@ enum:
       - [super_tuyau, "Case contenant un Super Tuyau™"]
       - [debris, "Case contenant des débris à déblayer"]
       - [pulsar, "Case contenant un pulsar"]
-      - [base, "Case appartenant à une base d'un des joueurs"]
+      - [base_joueur, "Case appartenant à une base d'un des joueurs"]
       - [interdit, "Case où aucune action n'est possible"]
 
 struct:

--- a/src/action_deplacer_aspiration.cc
+++ b/src/action_deplacer_aspiration.cc
@@ -27,7 +27,8 @@ int ActionDeplacerAspiration::check(const GameState& st) const
         return POSITION_INVALIDE;
     if (source_ == destination_)
         return DEPLACEMENT_INVALIDE;
-    if (source != case_type::BASE || destination != case_type::BASE)
+    if (source != case_type::BASE_JOUEUR ||
+        destination != case_type::BASE_JOUEUR)
         return PAS_DANS_BASE;
     if (st.get_cell_owner(source_) != static_cast<unsigned>(player_id_) ||
         st.get_cell_owner(destination_) != static_cast<unsigned>(player_id_))

--- a/src/api.cc
+++ b/src/api.cc
@@ -196,7 +196,7 @@ std::vector<position> Api::base_ennemie()
 /// Renvoie -1 si la position n'est pas celle d'une base.
 int Api::puissance_aspiration(position position)
 {
-    if (game_state_->get_cell_type(position) == BASE)
+    if (game_state_->get_cell_type(position) == BASE_JOUEUR)
         return game_state_->get_vacuum(position);
     else
         return -1;

--- a/src/constant.hh
+++ b/src/constant.hh
@@ -93,7 +93,7 @@ typedef enum case_type
     SUPER_TUYAU, /* <- Case contenant un Super Tuyau™ */
     DEBRIS,      /* <- Case contenant des débris à déblayer */
     PULSAR,      /* <- Case contenant un pulsar */
-    BASE,        /* <- Case appartenant à une base d'un des joueurs */
+    BASE_JOUEUR, /* <- Case appartenant à une base d'un des joueurs */
     INTERDIT,    /* <- Case où aucune action n'est possible */
 } case_type;
 

--- a/src/dumper.cc
+++ b/src/dumper.cc
@@ -159,7 +159,8 @@ static void dump_map(std::ostream& ss, const GameState& st)
                << "\"type\": \"" << st.get_cell_type(p) << "\""
                << ", \"owner\": " << st.get_cell_owner(p)
                << ", \"plasma\": " << st.get_plasma(p) << ", \"vacuum\": "
-               << (st.get_cell_type(p) == BASE ? st.get_vacuum(p) : 0) << "}";
+               << (st.get_cell_type(p) == BASE_JOUEUR ? st.get_vacuum(p) : 0)
+               << "}";
         }
     ss << "]";
 }

--- a/src/game_state.cc
+++ b/src/game_state.cc
@@ -64,7 +64,7 @@ GameState::GameState(std::istream& board_stream, const rules::Players& players)
         for (unsigned j = 0; j < 4; j++)
         {
             if (N / 3 <= i && i < N - N / 3)
-                cell(wall[j]) = {case_type::BASE, 0, player_ids_[j / 2]};
+                cell(wall[j]) = {case_type::BASE_JOUEUR, 0, player_ids_[j / 2]};
             else
                 cell(wall[j]) = {case_type::INTERDIT, 0, 0};
         }
@@ -258,7 +258,7 @@ void GameState::increase_plasma(position p, double plasma)
 {
     assert(plasma > 0);
     auto& c = cell(p);
-    if (c.type == BASE)
+    if (c.type == BASE_JOUEUR)
         player_info_.at(c.owner).collect_plasma(plasma);
     else
     {
@@ -309,7 +309,7 @@ std::vector<position> GameState::direction_plasma(position p)
         {
             auto q = p + delta;
             auto t = cell(q).type;
-            if ((t == TUYAU || t == SUPER_TUYAU || t == BASE) &&
+            if ((t == TUYAU || t == SUPER_TUYAU || t == BASE_JOUEUR) &&
                 distances[board_index(q)] < d)
                 directions.push_back(q);
         }
@@ -351,7 +351,7 @@ void GameState::move_plasma()
             continue; // Disconnected plasma disappears.
         const double plasma = std::get<2>(top) / n_dirs;
         for (const auto p : dirs)
-            if (steps == 1 || cell(p).type == BASE)
+            if (steps == 1 || cell(p).type == BASE_JOUEUR)
                 increase_plasma(p, plasma);
             else
                 plasmas.emplace(steps - 1, p, plasma);
@@ -402,7 +402,7 @@ bool GameState::in_bounds(position p) const
 
 const unsigned& GameState::vacuum_at(position p) const
 {
-    assert(cell(p).type == BASE);
+    assert(cell(p).type == BASE_JOUEUR);
     const int offset = TAILLE_TERRAIN / 3;
     if (p.y == 0)
         return vacuums_[0][p.x - offset];

--- a/src/game_state.hh
+++ b/src/game_state.hh
@@ -90,7 +90,7 @@ struct Cell
     double plasma;
 
     // ID of either:
-    // - the owner of a BASE;
+    // - the owner of a BASE_JOUEUR;
     // - the player who built a TUYAU;
     // - the one who upgraded one to a SUPER_TUYAU.
     // In the last two cases, this information has no effect on gameplay,
@@ -147,7 +147,7 @@ public:
     bool get_vacuum_moved() const { return vacuum_moved_; }
     void set_vacuum_moved(bool);
 
-    /// Get the vacuum power of a given position, that must be a BASE
+    /// Get the vacuum power of a given position, that must be a BASE_JOUEUR
     unsigned get_vacuum(position) const;
     void decrement_vacuum(position);
     void increment_vacuum(position);
@@ -170,8 +170,8 @@ public:
     double get_plasma(position) const;
     void clear_plasma(position);
 
-    // Should be called on a TUYAU, a SUPER_TUYAU or a BASE. In the last case,
-    // the owner collects the plasma.
+    // Should be called on a TUYAU, a SUPER_TUYAU or a BASE_JOUEUR. In the last
+    // case, the owner collects the plasma.
     void increase_plasma(position, double);
 
     /// Get a player's score. The id must be valid.
@@ -192,7 +192,7 @@ public:
     std::vector<position> direction_plasma(position);
 
     /// Move plasma at the end of a turn. Plasma that is not connected to
-    /// any 'BASE' cell is lost.
+    /// any 'BASE_JOUEUR' cell is lost.
     void move_plasma();
 
     /// Make pulsars produce plasma.
@@ -224,7 +224,7 @@ private:
     // Base vacuum on four sides (Top, Bottom, Left, Right)
     std::array<std::array<unsigned, LONGUEUR_BASE>, 4> vacuums_;
 
-    // The lengths of the shortest paths from pipes to 'BASE' cells.
+    // The lengths of the shortest paths from pipes to 'BASE_JOUEUR' cells.
     // MAX_INT represents cells unreachable from bases.
     std::shared_ptr<matrix<int>> board_distances_;
 };

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -139,8 +139,8 @@ std::string convert_to_string(case_type in)
         return "\"debris\"";
     case PULSAR:
         return "\"pulsar\"";
-    case BASE:
-        return "\"base\"";
+    case BASE_JOUEUR:
+        return "\"base_joueur\"";
     case INTERDIT:
         return "\"interdit\"";
     }
@@ -537,8 +537,8 @@ std::ostream& operator<<(std::ostream& os, case_type v)
     case PULSAR:
         os << "PULSAR";
         break;
-    case BASE:
-        os << "BASE";
+    case BASE_JOUEUR:
+        os << "BASE_JOUEUR";
         break;
     case INTERDIT:
         os << "INTERDIT";

--- a/src/tests/test-action_construire.cc
+++ b/src/tests/test-action_construire.cc
@@ -15,7 +15,7 @@ TEST_F(ActionTest, Construire_ConstructionImpossible)
     // players shouldn't be able to build pipes on bases
     ActionConstruire act(TEST_BASE, PLAYER_1);
     EXPECT_EQ(CONSTRUCTION_IMPOSSIBLE, act.check(*st));
-    EXPECT_EQ(BASE, st->get_cell_type(TEST_BASE));
+    EXPECT_EQ(BASE_JOUEUR, st->get_cell_type(TEST_BASE));
 
     // players shouldn't be able to build pipes on pulsars
     ActionConstruire act2(TEST_PULSAR_POSITION, PLAYER_1);

--- a/src/tests/test-api.cc
+++ b/src/tests/test-api.cc
@@ -38,7 +38,7 @@ TEST_F(ApiTest, Api_TypeCase)
         EXPECT_EQ(VIDE, player.api->type_case({1, 1}));
 
         EXPECT_EQ(INTERDIT, player.api->type_case({0, 1}));
-        EXPECT_EQ(BASE, player.api->type_case({0, TAILLE_TERRAIN / 2}));
+        EXPECT_EQ(BASE_JOUEUR, player.api->type_case({0, TAILLE_TERRAIN / 2}));
     }
 }
 


### PR DESCRIPTION
To avoid any conflict with the C# keyword "base".
Even if the conflict will not happen, because base will be capitalize,
better be extra safe with keyword conflicts.